### PR TITLE
added a script to install the sonarqube helm chart on k8s and a yaml …

### DIFF
--- a/init-cluster.sh
+++ b/init-cluster.sh
@@ -128,6 +128,15 @@ fi
 echo
 
 # ------------------------------------------------------------------------------
+# Sonarqube Setup
+# ------------------------------------------------------------------------------
+if ask "Sonarqube is a tool used to analyze code for smells and other bugs.\nInstall and configure Sonarqube?" Y; then
+  echo
+  "${BASEDIR}"/scripts/install-sonarqube.sh
+fi
+echo
+
+# ------------------------------------------------------------------------------
 # Spinnaker Setup
 # ------------------------------------------------------------------------------
 if ask "Spinnaker is a continuous deliver pipeline tool for distributing your applications to cluster.\nThis is under construction and experimental.\nInstall and configure Spinnaker?" N; then

--- a/scripts/install-jenkins.sh
+++ b/scripts/install-jenkins.sh
@@ -116,7 +116,12 @@ helm upgrade --install jenkins --wait --namespace jenkins stable/jenkins --value
 spinner "Installing Jenkins onto Kubernetes cluster"
 
 # Jenkins access to the registry, actual secret is copied by secret replicator service
-kubectl create secret -n jenkins "${BASEDIR}"/templates/regcred-blank.yaml"
+kubectl create -f "${BASEDIR}/templates/regcred-blank.yaml" --namespace jenkins
+
+# Jenkins access to sonarqube host url, actual configMap is copied by replicator service
+kubectl create configMap sonarqube-host-url --namespace jenkins
+kubectl annotate configMap sonarqube-host-url --namespace jenkins replicator.v1.mittwald.de/replicate-from=sonarqube/sonarqube-host-url
+
 
 echo -e "\033[32mJenkins is available at https://${JENKINS_FQDN}\033[39m"
 JENKINS_PASSWORD=$(printf $(kubectl get secret --namespace jenkins jenkins -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo)

--- a/scripts/install-sonarqube.sh
+++ b/scripts/install-sonarqube.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+BASEDIR=$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )")
+source "${BASEDIR}/scripts/functions.sh"
+
+# -----------------------------------------------------------------------------
+# Install Sonarqube
+# -----------------------------------------------------------------------------
+# When installing Sonarqube, we want to first check if there is an existing
+# Block Storage Volume available. If there is, we'll use that, otherwise
+# we want to create a new volume. Once the volume is present, we can move
+# on to setting up the PV/PVC for Sonarqube, and finally installing the
+# Sonarqube instance itself on the Kubernetes cluster.
+# -----------------------------------------------------------------------------
+
+echo "Sonarqube will now be installed onto the Kubernetes cluster."
+echo
+
+# TODO:
+#   Check for existing volume
+#   Retrieve the list of volumes in DigitalOcean.
+
+# Ask for fully qualified domain name
+echo
+echo -en "\033[33mWhat is the FQDN that Sonarqube will be hosted from?\033[39m "
+echo -e "Example: https://sonarqube.rootdomain.com, assuming *.rootdomain.com is the DNS A record."
+read -p "Jenkins domain name: https://" SONARQUBE_FQDN
+
+# Strip out 'http://' and 'https://'.
+SONARQUBE_FQDN=$(echo "${SONARQUBE_FQDN}" | sed -e 's/http[s]\{0,1\}:\/\///g')
+echo
+
+# Staging or Production
+echo -e "\033[33mFollow fair use policies by only choosing Production if you are ready to go live with Sonarqube. What cluster issuer type do you want to use?\033[39m" | fold -s
+CLUSTER_ISSUERS=("letsencrypt-staging" "letsencrypt-prod")
+select_option "${CLUSTER_ISSUERS[@]}"
+choice=$?
+CLUSTER_ISSUER="${CLUSTER_ISSUERS[$choice]}"
+echo
+
+# The initial password of Sonarqube admin.
+ADMIN_PASSWORD=$(head /dev/urandom | LC_ALL=C tr -dc A-Za-z0-9 | head -c 75)
+
+kubectl delete secret sonarqube --namespace kube-system
+kubectl create secret generic sonarqube --from-literal=SONARQUBE_ADMIN_PASSWORD="${ADMIN_PASSWORD}" --namespace kube-system
+kubectl annotate secret sonarqube --namespace kube-system replicator.v1.mittwald.de/replication-allowed='true' replicator.v1.mittwald.de/replication-allowed-namespaces='sonarqube'
+
+# Configure Sonarqube values
+echo "Configuring Sonarqube. This will take 2-3 minutes."
+sed -E 's/\[HOSTNAME]/'"${SONARQUBE_FQDN}"'/;s/\[CLUSTER_ISSUER]/'"${CLUSTER_ISSUER}"'/' \
+  "${BASEDIR}"/templates/sonarqube-values.yaml > "${BASEDIR}"/files/sonarqube-values.yaml
+
+# Install Sonarqube
+helm upgrade --install sonarqube stable/sonarqube --wait --namespace sonarqube --values "${BASEDIR}"/files/sonarqube-values.yaml > /dev/null & \
+spinner "Installing Sonarqube onto Kubernetes cluster"
+
+#This should be more dynamic than just waiting for two minutes. However, we do need to wait, because if we don't the curl command below won't be able to execute.  
+#Ideally we put a loop of some kind in here that checks if the website is running and every n seconds and then once it returns a certain code, the loop breaks.
+#For now this will suffice.
+echo "Waiting for ${SONARQUBE_FQDN} to be up and running."
+sleep 120 
+
+# Change the admin password using the Sonarqube web api and a curl command
+echo "Setting the admin password"
+curl -X POST -u admin:admin "https://${SONARQUBE_FQDN}/api/users/change_password?login=admin&password=${ADMIN_PASSWORD}&previousPassword=admin"
+
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     machine=Linux;;
+    Darwin*)    machine=Mac;;
+    CYGWIN*)    machine=Cygwin;;
+    MINGW*)     machine=MinGw;;
+    *)          machine="UNKNOWN:${unameOut}"
+esac
+
+# Copy token to the administrator's operating system clipboard
+if [ $machine == "Mac" ]; then
+  echo $ADMIN_PASSWORD | pbcopy
+elif [ $machine == "Linux" ]; then
+  echo $ADMIN_PASSWORD | xclip -selection clipboard -i
+elif [ $machine == "Cygwin" ]; then
+  echo $ADMIN_PASSWORD > /dev/clipboard
+fi
+
+echo "Sonarqube admin password is now in your $machine clipboard."
+echo 
+echo "Sonarqube sucessfully installed."

--- a/scripts/install-sonarqube.sh
+++ b/scripts/install-sonarqube.sh
@@ -5,7 +5,7 @@
 #their instance of Sonarqube in either a production or staging environment. If they choose production, this script will 
 #stand up Sonarqube on the FQDN, wait for the url to return a 200 status code, and change the admin password via a curl command.
 #If however, they choose staging, this script will call a port-forward command to serve the Sonarqube dashboard on the localhost
-#and then it will call the Sonarqube api via the localhost as opposed to the FQDN which is not directly accessible. The following
+#and then it will call the Sonarqube api via the localhost as opposed to the FQDN which is not directly accessible during staging. The following
 #function allows this script to perform the same setup for both production and staging environments based on the argument passed to
 #the function.
 
@@ -97,7 +97,7 @@ if [ $CLUSTER_ISSUER == "letsencrypt-prod" ]; then
   #Check to see if the status code is 200.
   while [ $server_status -ne 200 ]
   do
-    #If it isn't, wait three seconds and check it again.
+    #If it isn't, wait a moment and check it again.
     sleep 10
     server_status=$(curl -s -o /dev/null -w "%{http_code}" https://${SONARQUBE_FQDN})
   done 

--- a/templates/sonarqube-values.yaml
+++ b/templates/sonarqube-values.yaml
@@ -1,5 +1,7 @@
 image:
-  tag: 7.6-community
+  #Using version 7.6 as opposed to the most current version 7.9 because the sonar-bitbucket-plugin will not work 
+  #with a version > 7.6 due to the self described "required preview mode" in newer versions of Sonarqube
+  tag: 7.6-community 
 
 service:
   type: ClusterIP
@@ -33,15 +35,14 @@ postgresql:
 sonarProperties:
   sonar.forceAuthentication: true
 
-# https://docs.sonarqube.org/display/PLUG/Plugin+Version+Matrix
+# For a list of more plugins to consider see https://docs.sonarqube.org/display/PLUG/Plugin+Version+Matrix
 plugins: 
-  install:
+  install: # Using version 5.13.1 of sonar-javap-plugin creates conflict with sonar-pmd-plugin that causes Sonarqube installation to fail
     - 'https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-5.13.0.18197.jar'
     - 'https://github.com/SonarQubeCommunity/sonar-pmd/releases/download/3.2.1/sonar-pmd-plugin-3.2.1.jar'
-    - 'https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.0/sonar-findbugs-plugin-3.11.0.jar'
-    - 'https://github.com/checkstyle/sonar-checkstyle/releases/download/4.20/checkstyle-sonar-plugin-4.20.jar'
-    - 'https://github.com/sbaudoin/sonar-yaml/releases/download/v1.4.2/sonar-yaml-plugin-1.4.2.jar' #added 6/23/19
-    - 'https://github.com/sbaudoin/sonar-ansible/releases/download/v2.2.0/sonar-ansible-plugin-2.2.0.jar' #added 6/23/19
-    - 'https://binaries.sonarsource.com/Distribution/sonar-python-plugin/sonar-python-plugin-1.14.0.3086.jar' #added 6/26/19
+    - 'https://github.com/spotbugs/sonar-findbugs/releases/download/3.12.0/sonar-findbugs-plugin-3.12.0.jar'
+    - 'https://github.com/checkstyle/sonar-checkstyle/releases/download/4.21/checkstyle-sonar-plugin-4.21.jar'
+    - 'https://github.com/sbaudoin/sonar-yaml/releases/download/v1.4.3/sonar-yaml-plugin-1.4.3.jar' 
+    - 'https://github.com/sbaudoin/sonar-ansible/releases/download/v2.2.0/sonar-ansible-plugin-2.2.0.jar' 
+    - 'https://binaries.sonarsource.com/Distribution/sonar-python-plugin/sonar-python-plugin-1.14.0.3086.jar'
     - 'https://github.com/Soyn/sonar-bitbucket-plugin/releases/download/v1.3.0/sonar-bitbucket-plugin-1.3.0.jar'
-

--- a/templates/sonarqube-values.yaml
+++ b/templates/sonarqube-values.yaml
@@ -1,0 +1,47 @@
+image:
+  tag: 7.6-community
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  hosts:
+    - name: [HOSTNAME]
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: [CLUSTER_ISSUER]
+    ingress.kubernetes.io/secure-backends: "true"
+  tls:
+    - secretName: sonar-tls-[CLUSTER_ISSUER]
+      hosts:
+        - [HOSTNAME]
+    
+metadata:
+  name: basic-ingress
+
+persistence:
+  size: 10Gi
+  accessMode: ReadWriteOnce
+
+postgresql:
+  persistence:
+    size: 10Gi
+
+
+sonarProperties:
+  sonar.forceAuthentication: true
+
+# https://docs.sonarqube.org/display/PLUG/Plugin+Version+Matrix
+plugins: 
+  install:
+    - 'https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-5.13.0.18197.jar'
+    - 'https://github.com/SonarQubeCommunity/sonar-pmd/releases/download/3.2.1/sonar-pmd-plugin-3.2.1.jar'
+    - 'https://github.com/spotbugs/sonar-findbugs/releases/download/3.11.0/sonar-findbugs-plugin-3.11.0.jar'
+    - 'https://github.com/checkstyle/sonar-checkstyle/releases/download/4.20/checkstyle-sonar-plugin-4.20.jar'
+    - 'https://github.com/sbaudoin/sonar-yaml/releases/download/v1.4.2/sonar-yaml-plugin-1.4.2.jar' #added 6/23/19
+    - 'https://github.com/sbaudoin/sonar-ansible/releases/download/v2.2.0/sonar-ansible-plugin-2.2.0.jar' #added 6/23/19
+    - 'https://binaries.sonarsource.com/Distribution/sonar-python-plugin/sonar-python-plugin-1.14.0.3086.jar' #added 6/26/19
+    - 'https://github.com/Soyn/sonar-bitbucket-plugin/releases/download/v1.3.0/sonar-bitbucket-plugin-1.3.0.jar'
+


### PR DESCRIPTION
Created a branch called Sonarqube which has two files install-sonarqube.sh and sonarqube-values.yaml. These two files would work together to provide the ability for the user to add a Sonarqube helm chart to their Kubernetes on Digital Ocean. 

Things that still need to be done in order for this addition to be complete/cleaner:

Add a step in the init-cluster.sh script that prompts the user to install Sonarqube.
Add code in the install-sonarqube script that searches for persistent volumes in Digital Ocean to allow for the retrieval of old projects/data should Sonarqube be taken off Kubernetes
General code review on install-sonarqube